### PR TITLE
Fix : dummy query instead of hard query

### DIFF
--- a/Check/DoctrineDbal.php
+++ b/Check/DoctrineDbal.php
@@ -20,7 +20,8 @@ class DoctrineDbal extends AbstractCheck
     public function check()
     {
         $connection = $this->manager->getConnection($this->connectionName);
-        $connection->fetchColumn('SELECT 1');
+        $query = $connection->getDriver()->getDatabasePlatform()->getDummySelectSQL();
+        $connection->fetchColumn($query);
 
         return new Success();
     }


### PR DESCRIPTION
"Select 1" doesn't work with oracle or DB2 ... I switched to the getDummySelectSQL provided DoctrineDbal.